### PR TITLE
Handle arrays, other improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 'use strict';
 
 const assign = require('lodash/assign');
+const some = require('lodash/some');
+
+function isKeywordMatch(keywords, key) {
+  return some(keywords, (keyword) => key.indexOf(keyword) !== -1);
+}
 
 /**
  * Parses an object and redacts any keys listed in keywords
@@ -14,7 +19,8 @@ function redact(target, keywords, replaceVal) {
   const replace = replaceVal || '[ REDACTED ]';
   const targetCopy = assign({}, target);
   for (const x in targetCopy) {
-    if (keywords.indexOf(x) > -1) {
+    const isMatch = isKeywordMatch(keywords, x);
+    if (isMatch) {
       targetCopy[x] = replace;
     } else if (targetCopy[x] === Object(targetCopy[x])) {
       targetCopy[x] = redact(targetCopy[x], keywords, replaceVal);

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const assign = require('lodash/assign');
 const some = require('lodash/some');
+const isArray = require('lodash/isArray');
 
 function isKeywordMatch(keywords, key) {
   return some(keywords, (keyword) =>
@@ -18,6 +19,15 @@ function isKeywordMatch(keywords, key) {
  * @return {object}              the new redacted object
  */
 function redact(target, keywords, replaceVal) {
+  if (isArray(target)) {
+    return target.map((val) => {
+      if (val === Object(val)) {
+        return redact(val, keywords, replaceVal);
+      }
+      return val;
+    });
+  }
+
   const replace = replaceVal || '[ REDACTED ]';
   const targetCopy = assign({}, target);
   for (const x in targetCopy) {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const assign = require('lodash/assign');
 const some = require('lodash/some');
 const isArray = require('lodash/isArray');
+const isObject = require('lodash/isObject');
 
 function isKeywordMatch(keywords, key) {
   return some(keywords, (keyword) =>
@@ -21,7 +22,7 @@ function isKeywordMatch(keywords, key) {
 function redact(target, keywords, replaceVal) {
   if (isArray(target)) {
     return target.map((val) => {
-      if (val === Object(val)) {
+      if (isObject(val))
         return redact(val, keywords, replaceVal);
       }
       return val;
@@ -34,7 +35,7 @@ function redact(target, keywords, replaceVal) {
     const isMatch = isKeywordMatch(keywords, x);
     if (isMatch) {
       targetCopy[x] = replace;
-    } else if (targetCopy[x] === Object(targetCopy[x])) {
+    } else if (isObject(targetCopy[x]))
       targetCopy[x] = redact(targetCopy[x], keywords, replaceVal);
     }
   }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ const assign = require('lodash/assign');
 const some = require('lodash/some');
 
 function isKeywordMatch(keywords, key) {
-  return some(keywords, (keyword) => key.indexOf(keyword) !== -1);
+  return some(keywords, (keyword) =>
+    key.toLowerCase().indexOf(keyword.toLowerCase()) !== -1
+  );
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const extend = require('util')._extend; // yoink
+const assign = require('lodash/assign');
 
 /**
  * Parses an object and redacts any keys listed in keywords
@@ -12,7 +12,7 @@ const extend = require('util')._extend; // yoink
  */
 function redact(target, keywords, replaceVal) {
   const replace = replaceVal || '[ REDACTED ]';
-  const targetCopy = extend({}, target);
+  const targetCopy = assign({}, target);
   for (const x in targetCopy) {
     if (keywords.indexOf(x) > -1) {
       targetCopy[x] = replace;

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function redact(target, keywords, replaceVal) {
     if (keywords.indexOf(x) > -1) {
       targetCopy[x] = replace;
     } else if (targetCopy[x] === Object(targetCopy[x])) {
-      targetCopy[x] = redact(targetCopy[x], keywords);
+      targetCopy[x] = redact(targetCopy[x], keywords, replaceVal);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "istanbul": "^0.4.1",
     "jasmine-node": "^1.14.5"
   },
-  "homepage": "https://github.com/shaunburdick/redact-object"
+  "homepage": "https://github.com/shaunburdick/redact-object",
+  "dependencies": {
+    "lodash": "^4.15.0"
+  }
 }

--- a/test/unit/redact-object.spec.js
+++ b/test/unit/redact-object.spec.js
@@ -41,4 +41,10 @@ describe('Redact Config', () => {
     const redacted = redact(testConfig, ['token']);
     expect(redacted['auth-token']).toEqual(redactVal);
   });
+
+  it('should be case-insensitive', () => {
+    const redacted = redact(testConfig, ['FOO']);
+    expect(redacted.foo).toEqual(redactVal);
+    expect(redacted.fizz.foo).toEqual(redactVal);
+  });
 });

--- a/test/unit/redact-object.spec.js
+++ b/test/unit/redact-object.spec.js
@@ -8,6 +8,7 @@ const testConfig = {
     foo: 'bar',
   },
   derp: 'poo',
+  'auth-token': 'foo',
 };
 
 const redactVal = '[ REDACTED ]';
@@ -34,5 +35,10 @@ describe('Redact Config', () => {
     const origValue = testConfig.foo;
     redact(testConfig, ['foo']);
     expect(testConfig.foo).toEqual(origValue);
+  });
+
+  it('match partial strings', () => {
+    const redacted = redact(testConfig, ['token']);
+    expect(redacted['auth-token']).toEqual(redactVal);
   });
 });

--- a/test/unit/redact-object.spec.js
+++ b/test/unit/redact-object.spec.js
@@ -9,6 +9,7 @@ const testConfig = {
   },
   derp: 'poo',
   'auth-token': 'foo',
+  'array': [{ foo: 'bar'}, 5],
 };
 
 const redactVal = '[ REDACTED ]';
@@ -18,6 +19,8 @@ describe('Redact Config', () => {
     const redacted = redact(testConfig, ['foo']);
     expect(redacted.foo).toEqual(redactVal);
     expect(redacted.fizz.foo).toEqual(redactVal);
+    expect(Array.isArray(redacted.array)).toBe(true);
+    expect(redacted.array).toEqual([{ foo: redactVal}, 5]);
   });
 
   it('should not redact unmatched keys', () => {

--- a/test/unit/redact-object.spec.js
+++ b/test/unit/redact-object.spec.js
@@ -12,6 +12,9 @@ const testConfig = {
   'array': [{ foo: 'bar'}, 5],
 };
 
+function NonPlainObject() {
+}
+
 const redactVal = '[ REDACTED ]';
 
 describe('Redact Config', () => {
@@ -49,5 +52,12 @@ describe('Redact Config', () => {
     const redacted = redact(testConfig, ['FOO']);
     expect(redacted.foo).toEqual(redactVal);
     expect(redacted.fizz.foo).toEqual(redactVal);
+  });
+
+  it('should throw with non-plain object', () => {
+    expect(() => {
+      const nonPlainObject = new NonPlainObject();
+      redact(nonPlainObject, ['FOO']);
+    }).toThrow();
   });
 });


### PR DESCRIPTION
This implements various changes I needed for my use case. Notably:
- Support arrays, returning a new array instead of converting it to an object
- Throw error if given value is not array or plain object — see de0b439 for more info
- Substring and case-insensitive matching — for example, if `"AUTH-TOKEN"` is the key, and one of the keywords is `"token"`, then the `"AUTH-TOKEN"` key will be redacted
